### PR TITLE
Added hint-claiming and unclaiming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ yarn-error.log*
 
 # idea files
 .idea
+
+Makefile

--- a/src/app/admin/actions.tsx
+++ b/src/app/admin/actions.tsx
@@ -4,6 +4,13 @@ import { auth } from "@/auth";
 import { hints } from "@/db/schema";
 import { db } from "@/db/index";
 import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+/*
+IMPORTANT TODO: Make sure to handle synchronization issues between
+multiple people trying to claim the same hint at the same time
+#BadFirstIssue
+*/
 
 export async function respondToHint(hintId: number, response: string) {
   const session = await auth();
@@ -16,6 +23,57 @@ export async function respondToHint(hintId: number, response: string) {
     .set({
       response,
       responseTime: new Date(),
+      status: "answered",
     })
     .where(eq(hints.id, hintId));
+
+  revalidatePath("/admin");
+}
+
+export async function claimHint(hintId: number) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    throw new Error("Not logged in");
+  }
+
+  if (session.user.role !== "admin") {
+    throw new Error("Not authorized");
+  }
+
+  const hint = await db.query.hints.findFirst({
+    where: eq(hints.id, hintId),
+  });
+
+  if (!hint) {
+    throw new Error("Hint not found");
+  }
+
+  if (hint.claimer && hint.claimer !== session.user.id) {
+    throw new Error("Hint already claimed");
+  }
+
+  await db
+    .update(hints)
+    .set({
+      claimer: session.user.id,
+      claimTime: new Date(),
+    })
+    .where(eq(hints.id, hintId));
+
+  revalidatePath("/admin");
+}
+
+export async function unclaimHint(hintId: number) {
+  const session = await auth();
+  if (session?.user?.role !== "admin") {
+    throw new Error("Not authorized");
+  }
+
+  await db
+    .update(hints)
+    .set({ claimer: null, claimTime: null })
+    .where(eq(hints.id, hintId));
+
+  revalidatePath("/admin");
 }

--- a/src/app/admin/actions.tsx
+++ b/src/app/admin/actions.tsx
@@ -34,11 +34,11 @@ export async function claimHint(hintId: number) {
   const session = await auth();
 
   if (!session?.user?.id) {
-    throw new Error("Not logged in");
+    throw new Error("Not logged in.");
   }
 
   if (session.user.role !== "admin") {
-    throw new Error("Not authorized");
+    throw new Error("Not authorized.");
   }
 
   const hint = await db.query.hints.findFirst({
@@ -46,11 +46,12 @@ export async function claimHint(hintId: number) {
   });
 
   if (!hint) {
-    throw new Error("Hint not found");
+    throw new Error("Hint not found.");
   }
 
   if (hint.claimer && hint.claimer !== session.user.id) {
-    throw new Error("Hint already claimed");
+    revalidatePath("/admin");
+    throw new Error("Hint claimed by " + hint.claimer + ".");
   }
 
   await db

--- a/src/app/admin/components/ClaimBox.tsx
+++ b/src/app/admin/components/ClaimBox.tsx
@@ -1,5 +1,6 @@
 import { Row } from "@tanstack/react-table";
 import { claimHint, unclaimHint } from "../actions";
+import { toast } from "~/hooks/use-toast";
 
 // TODO: Add refund hint functionality
 // TODO: Actually keep track of number of hints claimed
@@ -20,7 +21,20 @@ export function ClaimBox<TData>({
         Claimed by:{" "}
         <button
           className="rounded-md border border-emerald-600 text-emerald-600"
-          onClick={() => claimHint(hintId)}
+          onClick={async () => {
+            try {
+              await claimHint(hintId);
+            } catch (error: any) {
+              toast({
+                title: "Error Claiming Hint",
+                description: error.message,
+              });
+            }
+            // toast({
+            //   title: "Hint already claimed.",
+            //   description: "Better luck next time.",
+            // });
+          }}
         >
           <p className="px-1">CLAIM</p>
         </button>

--- a/src/app/admin/components/ClaimBox.tsx
+++ b/src/app/admin/components/ClaimBox.tsx
@@ -1,0 +1,44 @@
+import { Row } from "@tanstack/react-table";
+import { claimHint, unclaimHint } from "../actions";
+
+// TODO: Add refund hint functionality
+// TODO: Actually keep track of number of hints claimed
+
+export function ClaimBox<TData>({
+  row,
+  userId,
+}: {
+  row: Row<TData>;
+  userId: string;
+}) {
+  const hintId = row.getValue("id") as number;
+  const claimer = row.getValue("claimer");
+
+  if (!claimer) {
+    return (
+      <p>
+        Claimed by:{" "}
+        <button
+          className="rounded-md border border-emerald-600 text-emerald-600"
+          onClick={() => claimHint(hintId)}
+        >
+          <p className="px-1">CLAIM</p>
+        </button>
+      </p>
+    );
+  } else if (claimer === userId && row.getValue("response") === null) {
+    return (
+      <p>
+        Claimed by:{" "}
+        <button
+          className="rounded-md border border-red-600 text-red-600"
+          onClick={() => unclaimHint(hintId)}
+        >
+          <p className="px-1">UNCLAIM</p>
+        </button>
+      </p>
+    );
+  } else {
+    return <p>Claimed by: {claimer as string}</p>;
+  }
+}

--- a/src/app/admin/components/Columns.tsx
+++ b/src/app/admin/components/Columns.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { hints } from "~/server/db/schema";
+
+/* TODO: 
+  Convert team ID to team name
+  Convert puzzle ID to puzzle name
+  Shorten request time to just the time (if it is today) and the date (if it is not today)
+  Exclude the year from the date
+  Display claimer as initials
+  #GoodFirstIssue
+*/
+
+export function formatTime(time: unknown) {
+  if (!(time instanceof Date)) {
+    return "";
+  }
+  return time.toLocaleString("en-US", {
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// Define the columns for the table using TanStack
+export const columns: ColumnDef<typeof hints.$inferSelect>[] = [
+  {
+    accessorKey: "id",
+    header: () => <div className="w-16">Id</div>,
+    cell: ({ row }) => (
+      <div className="w-16 truncate">{row.getValue("id")}</div>
+    ),
+  },
+  {
+    accessorKey: "puzzleId",
+    header: () => <div className="w-24">Puzzle</div>,
+    cell: ({ row }) => (
+      <div className="w-16 truncate">{row.getValue("puzzleId")}</div>
+    ),
+  },
+  {
+    accessorKey: "teamId",
+    header: () => <div className="w-24">Team</div>,
+    cell: ({ row }) => (
+      <div className="w-24 truncate">{row.getValue("teamId")}</div>
+    ),
+  },
+  {
+    accessorKey: "request",
+    header: () => <div className="w-64">Request</div>,
+    cell: ({ row }) => (
+      <div className="w-64 truncate">{row.getValue("request")}</div>
+    ),
+  },
+  {
+    accessorKey: "response",
+    header: () => <div className="w-64">Response</div>,
+    cell: ({ row }) => (
+      <div className="w-64 truncate">{row.getValue("response")}</div>
+    ),
+  },
+  {
+    accessorKey: "requestTime",
+    header: () => <div className="w-32">Request Time</div>,
+    cell: ({ row }) => {
+      const time = row.getValue("requestTime");
+      return <div className="w-32 truncate font-medium">{formatTime(time)}</div>;
+    },
+  },
+  {
+    accessorKey: "claimer",
+    header: () => <div className="w-24">Claimed By</div>,
+    cell: ({ row }) => (
+      <div className="w-24 truncate">{row.getValue("claimer")}</div>
+    ),
+  },
+  // In HintTable, we set the initial state to hide them
+  {
+    header: () => null,
+    accessorKey: "claimTime",
+  },
+  {
+    header: () => null,
+    accessorKey: "responseTime",
+  },
+];

--- a/src/app/admin/components/RequestBox.tsx
+++ b/src/app/admin/components/RequestBox.tsx
@@ -1,0 +1,16 @@
+import { Label } from "~/components/ui/label";
+import { Textarea } from "~/components/ui/textarea";
+import { Row } from "@tanstack/react-table";
+
+export function RequestBox<TData>({ row }: { row: Row<TData> }) {
+  return (
+    <div className="grid w-full gap-1.5">
+      <Label htmlFor={`hint-request-${row.getValue("id")}`}>Request</Label>
+      <Textarea
+        value={row.getValue("request")}
+        id={`hint-request-${row.getValue("id")}`}
+        readOnly
+      />
+    </div>
+  );
+}

--- a/src/app/admin/components/ResponseBox.tsx
+++ b/src/app/admin/components/ResponseBox.tsx
@@ -1,0 +1,48 @@
+import { Row } from "@tanstack/react-table";
+import { respondToHint } from "../actions";
+import { Textarea } from "~/components/ui/textarea";
+import { Button } from "~/components/ui/button";
+import { Label } from "~/components/ui/label";
+
+export function ResponseBox<TData>({
+  row,
+  currHinter,
+}: {
+  row: Row<TData>;
+  currHinter: string;
+}) {
+  if (row.getValue("response")) {
+    return (
+      <div className="grid w-full gap-1.5">
+        <Label htmlFor={`hint-response-${row.getValue("id")}`}>Response</Label>
+        <Textarea
+          value={row.getValue("response")}
+          id={`hint-response-${row.getValue("id")}`}
+          readOnly
+        />
+      </div>
+    );
+  }
+
+  if (row.getValue("claimer") == currHinter)
+    return (
+      <div className="grid full gap-1.5">
+        <Label htmlFor={`hint-response-${row.getValue("id")}`}>Response</Label>
+        <Textarea
+          placeholder="No response yet"
+          id={`hint-response-${row.getValue("id")}`}
+        />
+        <Button
+          className="w-fit"
+          onClick={() => {
+            const textarea = document.getElementById(
+              `hint-response-${row.getValue("id")}`,
+            ) as HTMLTextAreaElement;
+            respondToHint(row.getValue("id"), textarea.value);
+          }}
+        >
+          Respond
+        </Button>
+      </div>
+    );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,8 +1,7 @@
 import { auth } from "@/auth";
 import { db } from "@/db/index";
-import { hints } from "@/db/schema";
-
-import { columns, DataTable } from "./components/HintTable";
+import { columns } from "./components/Columns";
+import { HintTable } from "./components/HintTable";
 
 export default async function Home() {
   const session = await auth();
@@ -10,11 +9,13 @@ export default async function Home() {
     return <p>You are not authorized to access this page.</p>;
   }
 
-  const data = await db.query.hints.findMany();
+  const data = (await db.query.hints.findMany()).sort(
+    (a, b) => b.requestTime!.getTime() - a.requestTime!.getTime(),
+  );
 
   return (
     <div className="container mx-auto py-10">
-      <DataTable columns={columns} data={data} />
+      <HintTable columns={columns} data={data} />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Toaster } from "@/components/ui/toaster";
 
 import { GeistSans } from "geist/font/sans";
 import { type Metadata } from "next";
+import { Providers } from "~/app/providers";
+
 export const metadata: Metadata = {
   title: "Brown Puzzle Hunt",
   description: "",
@@ -16,9 +18,11 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${GeistSans.variable}`}>
       <body>
-        <TopNav />
-        <main>{children}</main>
-        <Toaster />
+        <Providers>
+          <TopNav />
+          <main>{children}</main>
+          <Toaster />
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -6,8 +6,7 @@ import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { useToast } from "~/hooks/use-toast";
-import { ToastAction } from "@/components/ui/toast";
+import { toast } from "~/hooks/use-toast";
 import {
   Form,
   FormLabel,
@@ -70,8 +69,6 @@ export function RegisterForm({}: RegisterFormProps) {
       interactionMode: undefined,
     },
   });
-
-  const { toast } = useToast();
 
   const onSubmit = async (data: z.infer<typeof registerFormSchema>) => {
     const result = await insertTeam(

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -119,9 +119,9 @@ export const hints = createTable("hint", {
 export const teamRelations = relations(teams, ({ many }) => ({
   guesses: many(guesses),
   // Hints requested by this team
-  requestedHints: many(hints, { relationName: "hints" }),
+  requestedHints: many(hints, { relationName: "requested_hints" }),
   // Hints claimed by this admin "team"
-  claimedHints: many(hints, { relationName: "claimer" }),
+  claimedHints: many(hints, { relationName: "claimed_hints" }),
 }));
 
 export const puzzleRelations = relations(puzzles, ({ many }) => ({
@@ -144,6 +144,7 @@ export const hintRelations = relations(hints, ({ one }) => ({
   team: one(teams, {
     fields: [hints.teamId],
     references: [teams.id],
+    relationName: "requested_hints",
   }),
   puzzle: one(puzzles, {
     fields: [hints.puzzleId],
@@ -152,5 +153,6 @@ export const hintRelations = relations(hints, ({ one }) => ({
   claimer: one(teams, {
     fields: [hints.claimer],
     references: [teams.id],
+    relationName: "claimed_hints",
   }),
 }));

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -103,17 +103,14 @@ export const hints = createTable("hint", {
 
   request: text("request").notNull(),
   requestTime: timestamp("request_time", { withTimezone: true }),
-
-  claimer: varchar("claimer", { length: 255 }),
+  claimer: varchar("claimer").references(() => teams.id),
   claimTime: timestamp("claim_time", { withTimezone: true }),
-
   response: text("response"),
   responseTime: timestamp("response_time", { withTimezone: true }),
-
   status: hintStatusEnum("status").notNull().default("no_response"),
 
   // Not included:
-  // refunded or obsolute statuses
+  // obsolute statuses
   // notify_emails, discord_id, is_followup
 });
 
@@ -146,5 +143,9 @@ export const hintRelations = relations(hints, ({ one }) => ({
   puzzle: one(puzzles, {
     fields: [hints.puzzleId],
     references: [puzzles.id],
+  }),
+  claimer: one(teams, {
+    fields: [hints.claimer],
+    references: [teams.id],
   }),
 }));

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -114,9 +114,14 @@ export const hints = createTable("hint", {
   // notify_emails, discord_id, is_followup
 });
 
+// TODO: Add indexes
+
 export const teamRelations = relations(teams, ({ many }) => ({
   guesses: many(guesses),
-  hints: many(hints),
+  // Hints requested by this team
+  requestedHints: many(hints, { relationName: "hints" }),
+  // Hints claimed by this admin "team"
+  claimedHints: many(hints, { relationName: "claimer" }),
 }));
 
 export const puzzleRelations = relations(puzzles, ({ many }) => ({


### PR DESCRIPTION
Added a hint-claiming and unclaiming button inside of each row. The response box is hidden until the user claims the hint.

Made the claimer column in the hint table reference the teamId column in the team table. This means that all hinters should log in to a unique admin account.

Wrapped the layout in a SessionProvider so that the `useSession` hook could be used in client components.

Refactored HintTable into multiple components.