### PR TITLE
Limit number of guesses per puzzle

### DIFF
--- a/src/app/puzzle/actions.tsx
+++ b/src/app/puzzle/actions.tsx
@@ -1,19 +1,13 @@
 "use server";
 
-import { db } from "~/server/db";
-import {
-  puzzles,
-  guesses,
-  roleEnum,
-  interactionModeEnum,
-  hints,
-} from "~/server/db/schema";
+import { db } from "@/db/index";
+import { puzzles, guesses, hints } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
-import { auth, signIn, signOut } from "@/auth";
-import { AuthError } from "next-auth";
-import { except } from "drizzle-orm/mysql-core";
+import { auth } from "@/auth";
+import { NUMBER_OF_GUESSES_PER_PUZZLE } from "~/hunt.config";
+import { revalidatePath } from "next/dist/server/web/spec-extension/revalidate";
 
-// Remember to handle errors in the GuessForm component
+// TODO: Handle errors in the GuessForm component
 export async function insertGuess(puzzleId: string, guess: string) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -22,22 +16,24 @@ export async function insertGuess(puzzleId: string, guess: string) {
 
   const puzzle = await db.query.puzzles.findFirst({
     where: eq(puzzles.id, puzzleId),
+    with: {
+      guesses: {
+        where: eq(guesses.teamId, session.user.id),
+      },
+    },
   });
 
   if (!puzzle) {
     throw new Error("Puzzle not found");
   }
 
-  // Maybe tell the user if they have already made a guess?
-  const duplicateGuess = await db.query.guesses.findFirst({
-    where: and(
-      eq(guesses.guess, guess),
-      eq(guesses.teamId, session.user.id),
-      eq(guesses.puzzleId, puzzleId),
-    ),
-  });
+  if (puzzle.guesses.length >= NUMBER_OF_GUESSES_PER_PUZZLE) {
+    revalidatePath(`/puzzle/${puzzleId}`);
+    throw new Error("No guesses left");
+  }
 
-  if (duplicateGuess) {
+  // TODO: Tell the user if they have already made a guess?
+  if (puzzle.guesses.find((g) => g.guess === guess)) {
     return;
   }
 
@@ -48,6 +44,8 @@ export async function insertGuess(puzzleId: string, guess: string) {
     isCorrect: puzzle.answer === guess,
     submitTime: new Date(),
   });
+
+  revalidatePath(`/puzzle/${puzzleId}`);
 }
 
 export async function insertHint(puzzleId: string, hint: string) {

--- a/src/app/puzzle/actions.tsx
+++ b/src/app/puzzle/actions.tsx
@@ -29,7 +29,7 @@ export async function insertGuess(puzzleId: string, guess: string) {
 
   if (puzzle.guesses.length >= NUMBER_OF_GUESSES_PER_PUZZLE) {
     revalidatePath(`/puzzle/${puzzleId}`);
-    throw new Error("No guesses left");
+    return;
   }
 
   // TODO: Tell the user if they have already made a guess?

--- a/src/app/puzzle/components/GuessForm.tsx
+++ b/src/app/puzzle/components/GuessForm.tsx
@@ -64,7 +64,8 @@ export function GuessForm({ puzzleId, numberOfGuessesLeft }: FormProps) {
                 <Input placeholder="Guess" {...field} />
               </FormControl>
               <FormDescription>
-                {numberOfGuessesLeft} {numberOfGuessesLeft === 1 ? "guess" : "guesses"} left
+                {numberOfGuessesLeft}{" "}
+                {numberOfGuessesLeft === 1 ? "guess" : "guesses"} left
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/src/app/puzzle/components/GuessForm.tsx
+++ b/src/app/puzzle/components/GuessForm.tsx
@@ -61,7 +61,7 @@ export function GuessForm({ puzzleId, numberOfGuessesLeft }: FormProps) {
           render={({ field }) => (
             <FormItem>
               <FormControl>
-                <Input placeholder="Guess" {...field} />
+                <Input {...field} />
               </FormControl>
               <FormDescription>
                 {numberOfGuessesLeft}{" "}

--- a/src/app/puzzle/components/GuessForm.tsx
+++ b/src/app/puzzle/components/GuessForm.tsx
@@ -3,12 +3,12 @@
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormMessage,
@@ -36,10 +36,10 @@ const formSchema = z.object({
 
 type FormProps = {
   puzzleId: string;
+  numberOfGuessesLeft: number;
 };
 
-export function GuessForm({ puzzleId }: FormProps) {
-  const router = useRouter();
+export function GuessForm({ puzzleId, numberOfGuessesLeft }: FormProps) {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -50,7 +50,6 @@ export function GuessForm({ puzzleId }: FormProps) {
   const onSubmit = async (data: z.infer<typeof formSchema>) => {
     await insertGuess(puzzleId, data.guess);
     form.reset();
-    router.refresh();
   };
 
   return (
@@ -64,6 +63,9 @@ export function GuessForm({ puzzleId }: FormProps) {
               <FormControl>
                 <Input placeholder="Guess" {...field} />
               </FormControl>
+              <FormDescription>
+                {numberOfGuessesLeft} {numberOfGuessesLeft === 1 ? "guess" : "guesses"} left
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/src/app/puzzle/puzzle1/page.tsx
+++ b/src/app/puzzle/puzzle1/page.tsx
@@ -9,6 +9,7 @@ import { GuessForm } from "~/app/puzzle/components/GuessForm";
 import { HintForm } from "~/app/puzzle/components/HintForm";
 import { PreviousGuessTable } from "~/app/puzzle/components/PreviousGuessTable";
 import { PreviousHintTable } from "~/app/puzzle/components/PreviousHintTable";
+import { NUMBER_OF_GUESSES_PER_PUZZLE } from "~/hunt.config";
 
 // TODO: Dynamically get the puzzle ID from the URL
 // #BadFirstIssue
@@ -26,6 +27,10 @@ export default async function Home() {
     ),
   });
 
+  const hasCorrectGuess = previousGuesses.some((guess) => guess.isCorrect);
+  const numberOfGuessesLeft =
+    NUMBER_OF_GUESSES_PER_PUZZLE - previousGuesses.length;
+
   const previousHints = await db.query.hints.findMany({
     where: and(
       eq(hints.teamId, session.user.id),
@@ -33,13 +38,19 @@ export default async function Home() {
     ),
   });
 
-  const hasCorrectGuess = previousGuesses.some((guess) => guess.isCorrect);
-
   return (
     <div className="flex min-h-screen flex-col items-center">
       <h1 className="m-4">Puzzle!</h1>
       <p className="m-4">What is the answer to this puzzle?</p>
-      {!hasCorrectGuess && <GuessForm puzzleId={PUZZLE_ID} />}
+      {!hasCorrectGuess && numberOfGuessesLeft > 0 && (
+        <GuessForm
+          puzzleId={PUZZLE_ID}
+          numberOfGuessesLeft={numberOfGuessesLeft}
+        />
+      )}
+      {numberOfGuessesLeft === 0 && !hasCorrectGuess && (
+        <div>You have no guesses left. Please contact HQ for help.</div>
+      )}
 
       <h1 className="m-4">Previous Guesses</h1>
       <PreviousGuessTable previousGuesses={previousGuesses} />

--- a/src/app/puzzle/puzzle2/page.tsx
+++ b/src/app/puzzle/puzzle2/page.tsx
@@ -9,6 +9,7 @@ import { GuessForm } from "~/app/puzzle/components/GuessForm";
 import { HintForm } from "~/app/puzzle/components/HintForm";
 import { PreviousGuessTable } from "~/app/puzzle/components/PreviousGuessTable";
 import { PreviousHintTable } from "~/app/puzzle/components/PreviousHintTable";
+import { NUMBER_OF_GUESSES_PER_PUZZLE } from "~/hunt.config";
 
 // TODO: Dynamically get the puzzle ID from the URL
 // #BadFirstIssue
@@ -26,6 +27,10 @@ export default async function Home() {
     ),
   });
 
+  const hasCorrectGuess = previousGuesses.some((guess) => guess.isCorrect);
+  const numberOfGuessesLeft =
+    NUMBER_OF_GUESSES_PER_PUZZLE - previousGuesses.length;
+
   const previousHints = await db.query.hints.findMany({
     where: and(
       eq(hints.teamId, session.user.id),
@@ -33,13 +38,19 @@ export default async function Home() {
     ),
   });
 
-  const hasCorrectGuess = previousGuesses.some((guess) => guess.isCorrect);
-
   return (
     <div className="flex min-h-screen flex-col items-center">
       <h1 className="m-4">Puzzle!</h1>
       <p className="m-4">What is the answer to this puzzle?</p>
-      {!hasCorrectGuess && <GuessForm puzzleId={PUZZLE_ID} />}
+      {!hasCorrectGuess && numberOfGuessesLeft > 0 && (
+        <GuessForm
+          puzzleId={PUZZLE_ID}
+          numberOfGuessesLeft={numberOfGuessesLeft}
+        />
+      )}
+      {numberOfGuessesLeft === 0 && !hasCorrectGuess && (
+        <div>You have no guesses left. Please contact HQ for help.</div>
+      )}
 
       <h1 className="m-4">Previous Guesses</h1>
       <PreviousGuessTable previousGuesses={previousGuesses} />
@@ -47,7 +58,7 @@ export default async function Home() {
       <HintForm puzzleId={PUZZLE_ID} />
 
       <h1 className="m-4">Previous Hints</h1>
-      <div>
+      <div className="w-1/2">
         <PreviousHintTable previousHints={previousHints} />
       </div>
     </div>

--- a/src/hunt.config.ts
+++ b/src/hunt.config.ts
@@ -1,7 +1,9 @@
 // NOTE: Account for daylight savings time
 // All times are in ISO
 // https://greenwichmeantime.com/articles/clocks/iso/
+
 export const REGISTRATION_START_TIME = new Date("2024-10-24T05:56:35Z");
 export const REGISTRATION_END_TIME = new Date("2024-11-20T05:56:35Z");
 export const HUNT_START_TIME = new Date("2024-10-24T05:59:00Z");
 export const HUNT_END_TIME = new Date("2024-11-20T05:56:35Z");
+export const NUMBER_OF_GUESSES_PER_PUZZLE = 20;


### PR DESCRIPTION
The number of guesses left is displayed under the guess input box. The guess form disappears once the max number of guesses is hit. The global NUMBER_OF_GUESSES_PER_PUZZLE can be set in hunt.config.ts. Server-side validation is necessary for synchronization.