### PR TITLE
Use admin team displayName in hint pages

### DIFF
--- a/src/app/(admin)/admin/hints/[slug]/page.tsx
+++ b/src/app/(admin)/admin/hints/[slug]/page.tsx
@@ -42,6 +42,7 @@ export default async function Page({
     where: eq(hints.id, hintId),
     with: {
       team: { columns: { displayName: true } },
+      claimer: { columns: { id: true, displayName: true } },
       puzzle: { columns: { name: true } },
     },
   });
@@ -75,7 +76,7 @@ export default async function Page({
         <h1>Answer a Hint</h1>
         <ClaimBox
           id={hint.id}
-          claimer={hint.claimer}
+          claimer={hint.claimer!.displayName}
           response={hint.response}
           userId={session.user.id}
         />

--- a/src/app/(admin)/admin/hints/[slug]/page.tsx
+++ b/src/app/(admin)/admin/hints/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function Page({
         <h1>Answer a Hint</h1>
         <ClaimBox
           id={hint.id}
-          claimer={hint.claimer!.displayName}
+          claimer={hint.claimer}
           response={hint.response}
           userId={session.user.id}
         />

--- a/src/app/(admin)/admin/hints/components/hint-page/ClaimBox.tsx
+++ b/src/app/(admin)/admin/hints/components/hint-page/ClaimBox.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { claimHint, unclaimHint } from "../../actions";
 import { toast } from "~/hooks/use-toast";
+import { HintClaimer } from "../hint-table/Columns";
 
 export default function ClaimBox({
   id,
@@ -9,7 +10,7 @@ export default function ClaimBox({
   userId,
 }: {
   id: number;
-  claimer: string | null;
+  claimer: HintClaimer;
   response: string | null;
   userId: string;
 }) {
@@ -48,7 +49,7 @@ export default function ClaimBox({
         </button>
       </div>
     );
-  } else if (claimer === userId && response === null) {
+  } else if (claimer.id === userId && response === null) {
     return (
       <div className="p-4">
         <button
@@ -60,6 +61,6 @@ export default function ClaimBox({
       </div>
     );
   } else {
-    return <div className="p-4">Claimed by: {claimer}</div>;
+    return <div className="p-4">Claimed by: {claimer.displayName}</div>;
   }
 }

--- a/src/app/(admin)/admin/hints/components/hint-table/ClaimBox.tsx
+++ b/src/app/(admin)/admin/hints/components/hint-table/ClaimBox.tsx
@@ -3,16 +3,21 @@ import { claimHint, unclaimHint } from "../../actions";
 import { toast } from "~/hooks/use-toast";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
+import { HintClaimer, HintWithRelations } from "./Columns";
 
 // TODO: Add refund hint functionality
 // TODO: Actually keep track of number of hints claimed
 
-export default function ClaimBox<TData>({ row }: { row: Row<TData> }) {
+export default function ClaimBox<TData>({
+  row,
+}: {
+  row: Row<HintWithRelations>;
+}) {
   const { data: session } = useSession();
   const userId = session?.user?.id as string;
 
   const hintId = row.getValue("id") as number;
-  const claimer = row.getValue("claimer") as string;
+  const claimer: HintClaimer = row.getValue("claimer");
 
   if (!claimer) {
     return (
@@ -33,7 +38,7 @@ export default function ClaimBox<TData>({ row }: { row: Row<TData> }) {
         <p className="px-1">CLAIM</p>
       </button>
     );
-  } else if (claimer === userId && row.getValue("responseTime") === null) {
+  } else if (claimer.id === userId && row.getValue("responseTime") === null) {
     return (
       <button
         className="rounded-md border border-red-600 text-red-600"
@@ -43,6 +48,6 @@ export default function ClaimBox<TData>({ row }: { row: Row<TData> }) {
       </button>
     );
   } else {
-    return <p>{claimer as string}</p>;
+    return <p>{claimer.displayName as string}</p>;
   }
 }

--- a/src/app/(admin)/admin/hints/components/hint-table/Columns.tsx
+++ b/src/app/(admin)/admin/hints/components/hint-table/Columns.tsx
@@ -25,8 +25,11 @@ export function formatTime(time: unknown) {
   });
 }
 
+export type HintClaimer = { id: string; displayName: string };
+
 export type HintWithRelations = typeof hints.$inferSelect & {
   team: { displayName: string };
+  claimer: HintClaimer | null;
   puzzle: { name: string };
 };
 

--- a/src/app/(admin)/admin/hints/components/hint-table/Columns.tsx
+++ b/src/app/(admin)/admin/hints/components/hint-table/Columns.tsx
@@ -25,11 +25,11 @@ export function formatTime(time: unknown) {
   });
 }
 
-export type HintClaimer = { id: string; displayName: string };
+export type HintClaimer = { id: string; displayName: string } | null;
 
 export type HintWithRelations = typeof hints.$inferSelect & {
   team: { displayName: string };
-  claimer: HintClaimer | null;
+  claimer: HintClaimer;
   puzzle: { name: string };
 };
 

--- a/src/app/(admin)/admin/hints/page.tsx
+++ b/src/app/(admin)/admin/hints/page.tsx
@@ -13,6 +13,7 @@ export default async function Home() {
     await db.query.hints.findMany({
       with: {
         team: { columns: { displayName: true } },
+        claimer: { columns: { id: true, displayName: true } },
         puzzle: { columns: { name: true } },
       },
     })


### PR DESCRIPTION
Note: the schema names the hint-claimer relation field as "claimer", which might conflict with the existing field of the same name. See below:
https://github.com/qiaochloe/bph-site/blob/02035da47867827f650f4afb39737d2616f8eed0/src/server/db/schema.ts#L117
https://github.com/qiaochloe/bph-site/blob/02035da47867827f650f4afb39737d2616f8eed0/src/server/db/schema.ts#L165-L169
Doesn't seem to affect functionality so I left it as is for now.