### PR TITLE
Implement hint limits

### DIFF
--- a/src/app/(hunt)/login/LoginForm.tsx
+++ b/src/app/(hunt)/login/LoginForm.tsx
@@ -39,7 +39,7 @@ export function LoginForm() {
 
   const onSubmit = async (data: z.infer<typeof loginFormSchema>) => {
     const result = await login(data.username, data.password);
-    if (result.error) {
+    if (result.error !== null) {
       setError(result.error);
     } else {
       if (session.data?.user?.role === "admin") {

--- a/src/app/(hunt)/puzzle/actions.tsx
+++ b/src/app/(hunt)/puzzle/actions.tsx
@@ -2,9 +2,12 @@
 
 import { db } from "@/db/index";
 import { puzzles, guesses, hints } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
+import { and, isNull, eq } from "drizzle-orm";
 import { auth } from "@/auth";
-import { NUMBER_OF_GUESSES_PER_PUZZLE } from "~/hunt.config";
+import {
+  getNumberOfHintsRemaining,
+  NUMBER_OF_GUESSES_PER_PUZZLE,
+} from "~/hunt.config";
 import { revalidatePath } from "next/dist/server/web/spec-extension/revalidate";
 
 // TODO: Handle errors in the GuessForm component
@@ -53,11 +56,22 @@ export async function insertHint(puzzleId: string, hint: string) {
     throw new Error("Not logged in");
   }
 
-  await db.insert(hints).values({
-    teamId: session.user.id,
-    puzzleId,
-    request: hint,
-    requestTime: new Date(),
-    status: "no_response",
-  });
+  const hasHint = (await getNumberOfHintsRemaining(session.user.id)) > 0;
+  const hasUnansweredHint = (await db.query.hints.findFirst({
+    columns: { id: true },
+    where: and(eq(hints.teamId, session.user.id), isNull(hints.response)),
+  }))
+    ? true
+    : false;
+
+  // Check the the team has a hint
+  if (hasHint && !hasUnansweredHint) {
+    await db.insert(hints).values({
+      teamId: session.user.id,
+      puzzleId,
+      request: hint,
+      requestTime: new Date(),
+      status: "no_response",
+    });
+  }
 }

--- a/src/app/(hunt)/puzzle/components/HintForm.tsx
+++ b/src/app/(hunt)/puzzle/components/HintForm.tsx
@@ -8,7 +8,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Form,
   FormControl,
@@ -18,9 +17,8 @@ import {
   FormMessage,
   FormLabel,
 } from "@/components/ui/form";
-
-import { Textarea } from "@/components/ui/textarea";
 import { insertHint } from "../actions";
+import Link from "next/link";
 
 const formSchema = z.object({
   hintRequest: z.string().min(1, {
@@ -30,9 +28,15 @@ const formSchema = z.object({
 
 type FormProps = {
   puzzleId: string;
+  hintsRemaining: number;
+  unansweredHint: { puzzleId: string; puzzleName: string } | null;
 };
 
-export default function HintForm({ puzzleId }: FormProps) {
+export default function HintForm({
+  puzzleId,
+  hintsRemaining,
+  unansweredHint,
+}: FormProps) {
   const router = useRouter();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -56,21 +60,41 @@ export default function HintForm({ puzzleId }: FormProps) {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Hint Request</FormLabel>
+              <FormDescription>
+                Please provide as much detail as possible to help us understand
+                where you're at and where you're stuck! Specific clues, steps,
+                and hypotheses are all helpful. If you're working with any
+                spreadsheets, diagrams, or external resources, you can include
+                links.
+              </FormDescription>
               <FormControl>
                 <AutosizeTextarea
                   maxHeight={500}
                   className="resize-none"
+                  disabled={!!unansweredHint}
                   {...field}
                 />
               </FormControl>
               <FormDescription>
-                Please be specific about what you need help with.
+                {hintsRemaining} {hintsRemaining === 1 ? "hint" : "hints"}{" "}
+                remaining.{" "}
+                {unansweredHint && (
+                  <>
+                    You have an outstanding hint on the puzzle{" "}
+                    <Link href={`/puzzle/${unansweredHint.puzzleId}`} className="text-blue-500">
+                      {unansweredHint.puzzleName}
+                    </Link>
+                    .
+                  </>
+                )}
               </FormDescription>
               <FormMessage />
             </FormItem>
           )}
         />
-        <Button type="submit">Submit</Button>
+        <Button type="submit" disabled={!!unansweredHint}>
+          Submit
+        </Button>
       </form>
     </Form>
   );

--- a/src/app/(hunt)/puzzle/components/HintForm.tsx
+++ b/src/app/(hunt)/puzzle/components/HintForm.tsx
@@ -71,17 +71,26 @@ export default function HintForm({
                 <AutosizeTextarea
                   maxHeight={500}
                   className="resize-none"
-                  disabled={!!unansweredHint}
+                  disabled={!!unansweredHint || hintsRemaining < 1}
                   {...field}
                 />
               </FormControl>
               <FormDescription>
-                {hintsRemaining} {hintsRemaining === 1 ? "hint" : "hints"}{" "}
-                remaining.{" "}
+                {hintsRemaining === 0 ? (
+                  "No hints remaining. "
+                ) : (
+                  <>
+                    {hintsRemaining} {hintsRemaining === 1 ? "hint" : "hints"}{" "}
+                    remaining.{" "}
+                  </>
+                )}
                 {unansweredHint && (
                   <>
                     You have an outstanding hint on the puzzle{" "}
-                    <Link href={`/puzzle/${unansweredHint.puzzleId}`} className="text-blue-500">
+                    <Link
+                      href={`/puzzle/${unansweredHint.puzzleId}`}
+                      className="text-blue-500"
+                    >
                       {unansweredHint.puzzleName}
                     </Link>
                     .
@@ -92,7 +101,7 @@ export default function HintForm({
             </FormItem>
           )}
         />
-        <Button type="submit" disabled={!!unansweredHint}>
+        <Button type="submit" disabled={!!unansweredHint || hintsRemaining < 1}>
           Submit
         </Button>
       </form>

--- a/src/app/(hunt)/puzzle/components/PreviousHintTable.tsx
+++ b/src/app/(hunt)/puzzle/components/PreviousHintTable.tsx
@@ -6,12 +6,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { hints } from "~/server/db/schema";
+
+type TableProps = {
+  id: number;
+  request: string;
+  response: string | null;
+}[];
 
 export default function PreviousHintTable({
   previousHints,
 }: {
-  previousHints: (typeof hints.$inferSelect)[];
+  previousHints: TableProps;
 }) {
   return (
     <Table className="table-fixed">

--- a/src/hunt.config.ts
+++ b/src/hunt.config.ts
@@ -2,8 +2,32 @@
 // All times are in ISO
 // https://greenwichmeantime.com/articles/clocks/iso/
 
+import { db } from "@/db/index";
+import { eq } from "drizzle-orm";
+import { count } from "drizzle-orm";
+import { hints } from "@/db/schema";
+
 export const REGISTRATION_START_TIME = new Date("2024-10-24T05:56:35Z");
 export const REGISTRATION_END_TIME = new Date("2024-11-20T05:56:35Z");
 export const HUNT_START_TIME = new Date("2024-10-24T05:59:00Z");
 export const HUNT_END_TIME = new Date("2024-11-20T05:56:35Z");
 export const NUMBER_OF_GUESSES_PER_PUZZLE = 20;
+
+export function getTotalHints(teamId: string) {
+  const currentTime = new Date();
+  const timeDifference = currentTime.getTime() - HUNT_START_TIME.getTime(); // In milliseconds
+  const rate = 3 * 60 * 60 * 1000; // 3 hours in milliseconds
+  return Math.floor(timeDifference / rate);
+}
+
+export async function numberOfHintsRemaining(teamId: string) {
+  const totalHints = getTotalHints(teamId);
+
+  const query = await db
+    .select({ count: count() })
+    .from(hints)
+    .where(eq(hints.teamId, teamId));
+  const usedHints = query[0]?.count ? query[0].count : 0;
+
+  return totalHints - usedHints;
+}

--- a/src/hunt.config.ts
+++ b/src/hunt.config.ts
@@ -13,6 +13,12 @@ export const HUNT_START_TIME = new Date("2024-11-09T05:59:00Z");
 export const HUNT_END_TIME = new Date("2024-11-20T05:56:35Z");
 export const NUMBER_OF_GUESSES_PER_PUZZLE = 20;
 
+/* HINTING SYSTEM
+ * Teams currently get a hint requeset every three hours since the start of the hunt.
+ * Teams cannot have more than one outstanding request at a time.
+ */
+
+/** Calculates the total number of hints given to a team */
 export function getTotalHints(teamId: string) {
   const currentTime = new Date();
   const timeDifference = currentTime.getTime() - HUNT_START_TIME.getTime(); // In milliseconds
@@ -20,6 +26,7 @@ export function getTotalHints(teamId: string) {
   return Math.floor(timeDifference / rate);
 }
 
+/** Calculates the total number of hints available to a team */
 export async function numberOfHintsRemaining(teamId: string) {
   const totalHints = getTotalHints(teamId);
 

--- a/src/hunt.config.ts
+++ b/src/hunt.config.ts
@@ -9,7 +9,7 @@ import { hints } from "@/db/schema";
 
 export const REGISTRATION_START_TIME = new Date("2024-10-24T05:56:35Z");
 export const REGISTRATION_END_TIME = new Date("2024-11-20T05:56:35Z");
-export const HUNT_START_TIME = new Date("2024-10-24T05:59:00Z");
+export const HUNT_START_TIME = new Date("2024-11-09T05:59:00Z");
 export const HUNT_END_TIME = new Date("2024-11-20T05:56:35Z");
 export const NUMBER_OF_GUESSES_PER_PUZZLE = 20;
 

--- a/src/hunt.config.ts
+++ b/src/hunt.config.ts
@@ -27,7 +27,7 @@ export function getTotalHints(teamId: string) {
 }
 
 /** Calculates the total number of hints available to a team */
-export async function numberOfHintsRemaining(teamId: string) {
+export async function getNumberOfHintsRemaining(teamId: string) {
   const totalHints = getTotalHints(teamId);
 
   const query = await db


### PR DESCRIPTION
Just getting this issue rolling. Teams gain a hint request every three hours since the hunt begins, and teams cannot have more than one outstanding hint. This information is displayed below the hint form on every puzzle page.