### PR TITLE
Make hint/team tables sortable

### DIFF
--- a/src/app/(admin)/admin/hints/components/hint-table/Columns.tsx
+++ b/src/app/(admin)/admin/hints/components/hint-table/Columns.tsx
@@ -72,6 +72,8 @@ export const columns: ColumnDef<HintWithRelations>[] = [
   {
     accessorKey: "claimer",
     header: () => <div className="w-32">Claimed By</div>,
+    sortingFn: (rowA: any): number =>
+      rowA.getValue("claimer") === null ? 1 : -1,
     cell: ({ row }) => (
       <div className="w-24 truncate">
         <ClaimBox row={row} />

--- a/src/app/(admin)/admin/hints/components/hint-table/HintTable.tsx
+++ b/src/app/(admin)/admin/hints/components/hint-table/HintTable.tsx
@@ -13,6 +13,8 @@ import {
   getPaginationRowModel,
   getFilteredRowModel,
   useReactTable,
+  SortingState,
+  getSortedRowModel,
 } from "@tanstack/react-table";
 
 import {
@@ -38,6 +40,7 @@ export function HintTable<TData, TValue>({
   const userId = session?.user?.id;
 
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [sorting, setSorting] = useState<SortingState>([]);
   const pageSize = 10;
 
   const table = useReactTable({
@@ -47,7 +50,10 @@ export function HintTable<TData, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
     state: {
+      sorting,
       columnFilters,
     },
     initialState: {
@@ -96,7 +102,16 @@ export function HintTable<TData, TValue>({
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={`header-${headerGroup.id}`}>
                   {headerGroup.headers.map((header) => (
-                    <TableHead key={header.id}>
+                    <TableHead
+                      key={header.id}
+                      onClick={() =>
+                        header.column.toggleSorting(
+                          header.column.getIsSorted() === "asc",
+                        )
+                      }
+                      className="hover:underline"
+                      role="button"
+                    >
                       {header.isPlaceholder
                         ? null
                         : flexRender(

--- a/src/app/(admin)/admin/teams/components/team-table/TeamTable.tsx
+++ b/src/app/(admin)/admin/teams/components/team-table/TeamTable.tsx
@@ -13,6 +13,8 @@ import {
   getPaginationRowModel,
   getFilteredRowModel,
   useReactTable,
+  SortingState,
+  getSortedRowModel,
 } from "@tanstack/react-table";
 
 import {
@@ -38,6 +40,7 @@ export function TeamTable<TData, TValue>({
   const userId = session?.user?.id;
 
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [sorting, setSorting] = useState<SortingState>([]);
   const pageSize = 10;
 
   const table = useReactTable({
@@ -47,7 +50,10 @@ export function TeamTable<TData, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
     state: {
+      sorting,
       columnFilters,
     },
     initialState: {
@@ -98,7 +104,16 @@ export function TeamTable<TData, TValue>({
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={`header-${headerGroup.id}`}>
                   {headerGroup.headers.map((header) => (
-                    <TableHead key={header.id}>
+                    <TableHead
+                      key={header.id}
+                      onClick={() =>
+                        header.column.toggleSorting(
+                          header.column.getIsSorted() === "asc",
+                        )
+                      }
+                      className="hover:underline"
+                      role="button"
+                    >
                       {header.isPlaceholder
                         ? null
                         : flexRender(


### PR DESCRIPTION
Columns are sortable alphabetically/chronologically by default. Hint table is sortable by claimed/unclaimed.